### PR TITLE
fix: deep data attributes scan

### DIFF
--- a/index.html
+++ b/index.html
@@ -26,6 +26,12 @@
       display: inline-block;
     }
 
+    .medium-box {
+      width: 100px;
+      height: 100px;
+      display: inline-block;
+    }
+
     p.p {
       margin: 25px;
       white-space: nowrap;
@@ -316,20 +322,20 @@ export default {
           <div class="big-box grab-bing border border-danger bg-secondary mx-auto mb-3" v-dragscroll
             v-on:dragscrollstart="eventTrigged('dragscrollstart')" v-on:dragscrollend="eventTrigged('dragscrollend')"
             v-on:dragscrollmove="eventTrigged('dragscrollmove', $event)">
-            <div class="bg-dark" style="width: 500px; height: 200px;" data-no-dragscroll>
-              <div class="small-box bg-danger m-5"></div>
-              <div class="small-box bg-danger m-5"></div>
-              <div class="small-box bg-danger m-5"></div>
+            <div class="bg-dark" style="width: 600px; height: 200px;">
+              <div class="medium-box bg-danger m-5" data-no-dragscroll><div class="small-box bg-warning"></div></div>
+              <div class="medium-box bg-danger m-5" data-no-dragscroll><div class="small-box bg-warning"></div></div>
+              <div class="medium-box bg-danger m-5" data-no-dragscroll><div class="small-box bg-warning"></div></div>
             </div>
           </div>
 
           <div class="big-box grab-bing border border-danger bg-secondary mx-auto" v-dragscroll:nochilddrag
             v-on:dragscrollstart="eventTrigged('dragscrollstart')" v-on:dragscrollend="eventTrigged('dragscrollend')"
             v-on:dragscrollmove="eventTrigged('dragscrollmove', $event)">
-            <div class="bg-dark" style="width: 500px; height: 200px;" data-dragscroll>
-              <div class="small-box bg-danger m-5"></div>
-              <div class="small-box bg-danger m-5"></div>
-              <div class="small-box bg-danger m-5"></div>
+            <div class="bg-dark" style="width: 600px; height: 200px;">
+              <div class="medium-box bg-danger m-5" data-dragscroll><div class="small-box bg-warning"></div></div>
+              <div class="medium-box bg-danger m-5" data-dragscroll><div class="small-box bg-warning"></div></div>
+              <div class="medium-box bg-danger m-5" data-dragscroll><div class="small-box bg-warning"></div></div>
             </div>
           </div>
         </div>

--- a/src/directive.js
+++ b/src/directive.js
@@ -22,7 +22,12 @@ let init = function (el, binding, vnode) {
       let hasFirstChildDrag = binding.arg === 'firstchilddrag'
       let isEl = clickedElement === el
       let isFirstChild = clickedElement === el.firstChild
-      let isDataDraggable = hasNoChildDrag ? typeof clickedElement.dataset.dragscroll !== 'undefined' : typeof clickedElement.dataset.noDragscroll === 'undefined'
+
+      let isDataDraggable = hasNoChildDrag
+        ? (typeof clickedElement.dataset.dragscroll !== 'undefined' ||
+          clickedElement.closest('[data-dragscroll]') !== null)
+        : (typeof clickedElement.dataset.noDragscroll === 'undefined' &&
+          clickedElement.closest('[data-no-dragscroll]') === null)
 
       if (!isEl && (!isDataDraggable || (hasFirstChildDrag && !isFirstChild))) {
         return


### PR DESCRIPTION
In my mind, the common behaviour for "data-no-dragscroll" and "data-dragscroll" would be that it takes the data attributes on the parent elements into account too.

Use closest selector to determine if there is a parent element that contains a data attribute.
Therefore we no longer need to define the data-attribute on every child.

Element.closest does not work with IE11. Needs a polyfill.

